### PR TITLE
feat: Expand enumerable types (queue, socket)

### DIFF
--- a/enumerable/concat.go
+++ b/enumerable/concat.go
@@ -1,5 +1,15 @@
 package enumerable
 
+// Concatenation is an extention of the enumerable interface allowing new sources
+// to be added after initial construction.
+type Concatenation[T any] interface {
+	Enumerable[T]
+	// Append appends a new source to this concatenation.
+	//
+	// This may be done after enumeration has begun.
+	Append(Enumerable[T])
+}
+
 type enumerableConcat[T any] struct {
 	sources            []Enumerable[T]
 	currentSourceIndex int
@@ -8,29 +18,49 @@ type enumerableConcat[T any] struct {
 // Concat takes zero to many source `Ènumerable`s and stacks them on top
 // of each other, resulting in one enumerable that will iterate through all
 // the values in all of the given sources.
-func Concat[T any](sources ...Enumerable[T]) Enumerable[T] {
+//
+// New sources may be added after iteration has begun.
+func Concat[T any](sources ...Enumerable[T]) Concatenation[T] {
 	return &enumerableConcat[T]{
 		sources:            sources,
 		currentSourceIndex: 0,
 	}
 }
 
+// Append appends a new source to this concatenation.
+//
+// This may be done after enumeration has begun.
+func (s *enumerableConcat[T]) Append(newSource Enumerable[T]) {
+	s.sources = append(s.sources, newSource)
+}
+
 func (s *enumerableConcat[T]) Next() (bool, error) {
+	startSourceIndex := s.currentSourceIndex
+	hasLooped := false
+
 	for {
 		if s.currentSourceIndex >= len(s.sources) {
-			return false, nil
+			if len(s.sources) < 1 || hasLooped {
+				return false, nil
+			}
+			s.currentSourceIndex = 0
+			hasLooped = true
 		}
 
 		currentSource := s.sources[s.currentSourceIndex]
 		hasValue, err := currentSource.Next()
 		if err != nil {
-			return false, nil
+			return false, err
 		}
 		if hasValue {
 			return true, nil
 		}
 
 		s.currentSourceIndex += 1
+
+		if s.currentSourceIndex == startSourceIndex {
+			return false, nil
+		}
 	}
 }
 

--- a/enumerable/concat.go
+++ b/enumerable/concat.go
@@ -39,6 +39,9 @@ func (s *enumerableConcat[T]) Next() (bool, error) {
 	hasLooped := false
 
 	for {
+		// If we have reached the end of the sources slice we need to loop
+		// back to the beginning.  It may be that earlier sources have gained
+		// items whilst we iterated though later sources.
 		if s.currentSourceIndex >= len(s.sources) {
 			if len(s.sources) < 1 || hasLooped {
 				return false, nil
@@ -59,6 +62,9 @@ func (s *enumerableConcat[T]) Next() (bool, error) {
 		s.currentSourceIndex += 1
 
 		if s.currentSourceIndex == startSourceIndex {
+			// If we are here it means that we have re-cycled
+			// all the way through the source slice and have found
+			// no new items.
 			return false, nil
 		}
 	}

--- a/enumerable/concat_test.go
+++ b/enumerable/concat_test.go
@@ -1,0 +1,130 @@
+package enumerable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcatYieldsNothingGivenEmpty(t *testing.T) {
+	concat := Concat[int]()
+
+	hasNext, err := concat.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestConcatYieldsItemsFromSource(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	v3 := 3
+	source1 := New([]int{v1, v2, v3})
+
+	concat := Concat(source1)
+
+	hasNext, err := concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r2, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v2, r2)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r3, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v3, r3)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestConcatYieldsItemsFromSourceInOrder(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	v3 := 3
+	v4 := 4
+	v5 := 5
+	v6 := 6
+	source1 := NewQueue[int]()
+	var s1 Enumerable[int] = source1
+	source2 := New([]int{v1, v2, v3})
+	source3 := New([]int{v4, v5})
+
+	concat := Concat(s1, source2, source3)
+
+	// Start yielding *before* source1 has any items
+	hasNext, err := concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	// Put an item into source1
+	err = source1.Put(v6)
+	require.NoError(t, err)
+
+	// Assert that the yielding of items from source2 is
+	// not interupted by source1 recieving items
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r2, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v2, r2)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r3, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v3, r3)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	// Assert that source3's items are yielded after
+	// source2's
+	r4, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v4, r4)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r5, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v5, r5)
+
+	// Then assert that source1's items are yielded
+	// as the concat circles back round
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r6, err := concat.Value()
+	require.NoError(t, err)
+	require.Equal(t, v6, r6)
+
+	hasNext, err = concat.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}

--- a/enumerable/queue.go
+++ b/enumerable/queue.go
@@ -1,0 +1,102 @@
+package enumerable
+
+// Queue is an extention of the enumerable interface allowing individual
+// items to be added into the enumerable.
+//
+// Added items will be yielded in a FIFO order.  Items may be added after
+// enumeration has begun.
+type Queue[T any] interface {
+	Enumerable[T]
+	// Put adds an item to the queue.
+	Put(T) error
+	// Size returns the current length of the backing array.
+	//
+	// This may include empty space where yield items previously resided.
+	// Useful for testing and debugging.
+	Size() int
+}
+
+type queue[T any] struct {
+	values       []T
+	currentIndex int
+	lastSetIndex int
+	zeroIndexSet bool
+}
+
+var _ Queue[any] = (*queue[any])(nil)
+
+// NewQueue creates an empty FIFO queue.
+//
+// It is implemented using a dynamically sized ring-buffer.
+func NewQueue[T any]() Queue[T] {
+	return &queue[T]{
+		values:       []T{},
+		currentIndex: -1,
+		lastSetIndex: -1,
+	}
+}
+
+func (q *queue[T]) Put(value T) error {
+	var index int
+	if !q.zeroIndexSet {
+		// If the zero-index is empty, we should use it - circling
+		// the ring buffer back to the beginning.
+		index = 0
+		q.zeroIndexSet = true
+	} else {
+		index = q.lastSetIndex + 1
+	}
+
+	if index >= len(q.values) {
+		// For now, increasing the size one at a time is likely optimal
+		// for the only useage of the queue type.  We may wish to change
+		// this at somepoint however.
+		newValues := make([]T, len(q.values)+1)
+		copy(newValues, q.values)
+		q.values = newValues
+	}
+
+	q.values[index] = value
+	q.lastSetIndex = index
+
+	return nil
+}
+
+func (q *queue[T]) Next() (bool, error) {
+	if q.currentIndex >= q.lastSetIndex && !q.zeroIndexSet {
+		// We have escaped the value-window and have no next value.
+		return false, nil
+	}
+
+	nextIndex := q.currentIndex + 1
+	if nextIndex == len(q.values) {
+		// Circle back to the beginning
+		nextIndex = 0
+	}
+
+	// If the next index is the zero-index the value is consumed (implicitly), so we update
+	// the flag here.
+	// Note: This may also be zero if this is the first Next call following either intialization
+	// or a reset, it cannot be moved inside the len(q.values) if-block above.
+	if nextIndex == 0 {
+		q.zeroIndexSet = false
+	}
+
+	q.currentIndex = nextIndex
+	return true, nil
+}
+
+func (q *queue[T]) Value() (T, error) {
+	return q.values[q.currentIndex], nil
+}
+
+func (q *queue[T]) Reset() {
+	q.values = []T{}
+	q.currentIndex = -1
+	q.lastSetIndex = -1
+	q.zeroIndexSet = false
+}
+
+func (q *queue[T]) Size() int {
+	return len(q.values)
+}

--- a/enumerable/queue.go
+++ b/enumerable/queue.go
@@ -22,10 +22,23 @@ type Queue[T any] interface {
 const growthSize int = 1
 
 type queue[T any] struct {
-	values          []T
-	currentIndex    int
-	lastSetIndex    int
-	zeroIndexSet    bool
+	// The values slice of this queue.
+	//
+	// Note: queue is implementated as a dynamically sized ring buffer, the zero index
+	// is not nessecarily the next/current value. Also note that values are not explicitly
+	// removed from this slice, which values are still 'in' the queue is tracked by index.
+	values []T
+
+	// The index of the current value.
+	currentIndex int
+
+	// The index of the last value added to the queue.
+	lastSetIndex int
+
+	// Will be true if values[0] has been set.
+	zeroIndexSet bool
+
+	// Will be true a value has been attempted to be read from an empty queue.
 	waitingForWrite bool
 }
 

--- a/enumerable/queue.go
+++ b/enumerable/queue.go
@@ -19,7 +19,7 @@ type Queue[T any] interface {
 // For now, increasing the size one at a time is likely optimal
 // for the only useage of the queue type.  We may wish to change
 // this at somepoint however.
-const growthRate int = 1
+const growthSize int = 1
 
 type queue[T any] struct {
 	values          []T
@@ -47,12 +47,12 @@ func (q *queue[T]) Put(value T) error {
 
 	if index >= len(q.values) {
 		if len(q.values) == 0 {
-			q.values = make([]T, growthRate)
+			q.values = make([]T, growthSize)
 			q.currentIndex = -1
 		} else if q.zeroIndexSet {
 			// If the zero index is occupied, we cannot loop back to it here
 			// and instead need to grow the values slice.
-			newValues := make([]T, len(q.values)+growthRate)
+			newValues := make([]T, len(q.values)+growthSize)
 			copy(newValues, q.values[:index])
 			q.values = newValues
 		} else {
@@ -67,12 +67,12 @@ func (q *queue[T]) Put(value T) error {
 		// e.g: [3,4,here,1,2]
 		// Note: The last value read should not be overwritten, as `Value`
 		// may be called multiple times on it after a single `Next` call.
-		newValues := make([]T, len(q.values)+growthRate)
+		newValues := make([]T, len(q.values)+growthSize)
 		copy(newValues, q.values[:index])
-		copy(newValues[index+growthRate:], q.values[index:])
+		copy(newValues[index+growthSize:], q.values[index:])
 		q.values = newValues
 		// Shift the current read index to reflect its new location.
-		q.currentIndex += growthRate
+		q.currentIndex += growthSize
 	}
 
 	if index == 0 {

--- a/enumerable/queue_test.go
+++ b/enumerable/queue_test.go
@@ -183,7 +183,7 @@ func TestQueueYieldsItemCorrectlyGivenCircle(t *testing.T) {
 	require.True(t, hasNext)
 
 	r1, err := queue.Value()
-	// [, 2, 3]
+	// [1, 2, 3]
 	require.NoError(t, err)
 	require.Equal(t, v1, r1)
 
@@ -192,19 +192,19 @@ func TestQueueYieldsItemCorrectlyGivenCircle(t *testing.T) {
 	require.True(t, hasNext)
 
 	r2, err := queue.Value()
-	// [, , 3]
+	// [, 2, 3]
 	require.NoError(t, err)
 	require.Equal(t, v2, r2)
 
 	queue.Put(v4)
-	// [4, , 3]
+	// [4, 2, 3]
 
 	hasNext, err = queue.Next()
 	require.NoError(t, err)
 	require.True(t, hasNext)
 
 	r3, err := queue.Value()
-	// [4, ,]
+	// [4, , 3]
 	require.NoError(t, err)
 	require.Equal(t, v3, r3)
 
@@ -213,7 +213,7 @@ func TestQueueYieldsItemCorrectlyGivenCircle(t *testing.T) {
 	require.True(t, hasNext)
 
 	r4, err := queue.Value()
-	// [, ,]
+	// [4, ,]
 	require.NoError(t, err)
 	require.Equal(t, v4, r4)
 
@@ -223,6 +223,87 @@ func TestQueueYieldsItemCorrectlyGivenCircle(t *testing.T) {
 
 	size := queue.Size()
 	require.Equal(t, 3, size)
+}
+
+func TestQueuePutsItemCorrectlyGivenCircle(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	v3 := 3
+	v4 := 4
+	v5 := 5
+	v6 := 6
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+	queue.Put(v2)
+	queue.Put(v3)
+	// [1, 2, 3]
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := queue.Value()
+	// [1, 2, 3]
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r2, err := queue.Value()
+	// [, 2, 3]
+	require.NoError(t, err)
+	require.Equal(t, v2, r2)
+
+	queue.Put(v4)
+	queue.Put(v5)
+	queue.Put(v6)
+	// [4, 5, 6, 2, 3]
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r3, err := queue.Value()
+	// [4, 5, 6, , 3]
+	require.NoError(t, err)
+	require.Equal(t, v3, r3)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r4, err := queue.Value()
+	// [, 5, 6, , 3]
+	require.NoError(t, err)
+	require.Equal(t, v4, r4)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r5, err := queue.Value()
+	// [, 5, 6, , ]
+	require.NoError(t, err)
+	require.Equal(t, v5, r5)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r6, err := queue.Value()
+	// [, , 6, , ]
+	require.NoError(t, err)
+	require.Equal(t, v6, r6)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+
+	size := queue.Size()
+	require.Equal(t, 5, size)
 }
 
 func TestQueueYieldsItemAddedAfterFullEnumeration(t *testing.T) {
@@ -257,4 +338,27 @@ func TestQueueYieldsItemAddedAfterFullEnumeration(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, v3, r3)
+}
+
+func TestQueueReturnsFalseAfterYieldingItemAddedAfterInitialEnumerations(t *testing.T) {
+	v1 := 1
+	queue := NewQueue[int]()
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+
+	queue.Put(v1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
 }

--- a/enumerable/queue_test.go
+++ b/enumerable/queue_test.go
@@ -1,0 +1,260 @@
+package enumerable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueueYieldsNothingGivenEmpty(t *testing.T) {
+	queue := NewQueue[int]()
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueYieldsSingleItemGivenValueAdded(t *testing.T) {
+	v1 := 1
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := queue.Value()
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueValueReturnsSameItemEachTime(t *testing.T) {
+	v1 := 1
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := queue.Value()
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	// Calling Value multiple times without progressing the enumeration
+	// via next should keep returning the same value
+	r1, err = queue.Value()
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueYields100ItemsGiven100ItemsAddedPreviously(t *testing.T) {
+	numberOfItems := 100
+	queue := NewQueue[int]()
+
+	for i := 1; i <= numberOfItems; i++ {
+		queue.Put(i)
+	}
+
+	for i := 1; i <= numberOfItems; i++ {
+		hasNext, err := queue.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		r1, err := queue.Value()
+		require.NoError(t, err)
+		require.Equal(t, i, r1)
+	}
+}
+
+func TestQueueYieldsItemsGiven100ItemsReadAsAdded(t *testing.T) {
+	numberOfItems := 100
+	queue := NewQueue[int]()
+
+	for i := 1; i <= numberOfItems; i++ {
+		queue.Put(i)
+
+		hasNext, err := queue.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		r1, err := queue.Value()
+		require.NoError(t, err)
+		require.Equal(t, i, r1)
+	}
+}
+
+func TestQueueYieldsItemsGiven100ItemsReadInPairsAsAdded(t *testing.T) {
+	numberOfItems := 100
+	queue := NewQueue[int]()
+
+	for i := 1; i <= numberOfItems; i = i + 2 {
+		vi1 := i
+		vi2 := i + 1
+		queue.Put(vi1)
+		queue.Put(vi2)
+
+		hasNext, err := queue.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		ri1, err := queue.Value()
+		require.NoError(t, err)
+		require.Equal(t, vi1, ri1)
+
+		hasNext, err = queue.Next()
+		require.NoError(t, err)
+		require.True(t, hasNext)
+
+		ri2, err := queue.Value()
+		require.NoError(t, err)
+		require.Equal(t, vi2, ri2)
+	}
+}
+
+func TestQueueYieldsNothinGivenReset(t *testing.T) {
+	queue := NewQueue[int]()
+
+	queue.Reset()
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueYieldsNothinGivenResetAfterValueAdded(t *testing.T) {
+	v1 := 1
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+	queue.Reset()
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueYieldsSingleItemGivenValueAddedAfterReset(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+	queue.Reset()
+	queue.Put(v2)
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := queue.Value()
+	require.NoError(t, err)
+	require.Equal(t, v2, r1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+}
+
+func TestQueueYieldsItemCorrectlyGivenCircle(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	v3 := 3
+	v4 := 4
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+	queue.Put(v2)
+	queue.Put(v3)
+	// [1, 2, 3]
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r1, err := queue.Value()
+	// [, 2, 3]
+	require.NoError(t, err)
+	require.Equal(t, v1, r1)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r2, err := queue.Value()
+	// [, , 3]
+	require.NoError(t, err)
+	require.Equal(t, v2, r2)
+
+	queue.Put(v4)
+	// [4, , 3]
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r3, err := queue.Value()
+	// [4, ,]
+	require.NoError(t, err)
+	require.Equal(t, v3, r3)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	r4, err := queue.Value()
+	// [, ,]
+	require.NoError(t, err)
+	require.Equal(t, v4, r4)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+
+	size := queue.Size()
+	require.Equal(t, 3, size)
+}
+
+func TestQueueYieldsItemAddedAfterFullEnumeration(t *testing.T) {
+	v1 := 1
+	v2 := 2
+	v3 := 3
+	queue := NewQueue[int]()
+
+	queue.Put(v1)
+	queue.Put(v2)
+
+	hasNext, err := queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.True(t, hasNext)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+	require.False(t, hasNext)
+
+	queue.Put(v3)
+
+	hasNext, err = queue.Next()
+	require.NoError(t, err)
+
+	require.True(t, hasNext)
+
+	r3, err := queue.Value()
+	require.NoError(t, err)
+
+	require.Equal(t, v3, r3)
+}

--- a/enumerable/socket.go
+++ b/enumerable/socket.go
@@ -1,0 +1,62 @@
+package enumerable
+
+import "github.com/sourcenetwork/immutable"
+
+// Socket is an extention of the enumerable interface allowing the source
+// to be replaced after initial construction.
+type Socket[T any] interface {
+	Enumerable[T]
+	// SetSource sets the source to this enumerable.
+	//
+	// This may be done after enumeration has begun.
+	SetSource(Enumerable[T])
+}
+
+type socket[T any] struct {
+	source immutable.Option[Enumerable[T]]
+}
+
+var _ Socket[any] = (*socket[any])(nil)
+
+// NewSocket creates a new Socket enumerable with no initial source.
+//
+// The source may be set, and even swapped out, later during its lifetime.
+// If enumeration begins before a source has been set it will behave as if empty.
+// Reseting the Socket will reset the source if there is one, and then remove it
+// as the source of this Socket.
+func NewSocket[T any]() Socket[T] {
+	return &socket[T]{
+		source: immutable.None[Enumerable[T]](),
+	}
+}
+
+// SetSource sets the source to this enumerable.
+//
+// This may be done after enumeration has begun.
+func (s *socket[T]) SetSource(newSource Enumerable[T]) {
+	s.source = immutable.Some(newSource)
+}
+
+func (s *socket[T]) Next() (bool, error) {
+	if !s.source.HasValue() {
+		return false, nil
+	}
+
+	return s.source.Value().Next()
+}
+
+func (s *socket[T]) Value() (T, error) {
+	if !s.source.HasValue() {
+		var v T
+		return v, nil
+	}
+
+	return s.source.Value().Value()
+}
+
+func (s *socket[T]) Reset() {
+	if s.source.HasValue() {
+		s.source.Value().Reset()
+	}
+	s.source = immutable.None[Enumerable[T]]()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
 module github.com/sourcenetwork/immutable
 
 go 1.18
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Resolves #6 

Expands enumerable types, adding a ring-buffer queue, and a socket, as well as allowing the Concat enumerable to receive new sources after enumeration has begun.

These are to be used by the lens-in-defra code. 

You can see how they are to be used in the WIP draft here: https://github.com/sourcenetwork/defradb/pull/1564 - the code in `Next` function in `lens/lens.go` is the most relevant, and whilst still fairly unpolished it should be fairly stable.